### PR TITLE
Fix datetime import and update pytest warning filter

### DIFF
--- a/cofoundai/tools/version_control.py
+++ b/cofoundai/tools/version_control.py
@@ -14,6 +14,7 @@ import shutil
 from typing import Dict, List, Any, Optional, Union, Tuple
 from pathlib import Path
 import json
+from datetime import datetime
 
 from cofoundai.tools.file_manager import FileManager
 from cofoundai.utils.logger import get_logger
@@ -429,7 +430,6 @@ ENV/
             self.add_files([])
             
             # Create a timestamp for the snapshot
-            from datetime import datetime
             timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             
             # Commit with snapshot message

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,4 +8,4 @@ python_classes = !TesterAgent !TestAgent
 
 # Filter warnings
 filterwarnings =
-    ignore::pydantic.warnings.PydanticDeprecatedSince20 
+    ignore::DeprecationWarning:pydantic.*


### PR DESCRIPTION
## Summary
- import `datetime` once in `version_control` for use in snapshot functions
- clean up pytest configuration to avoid missing `pydantic.warnings`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6858788b03fc8329b6a6f9de6770d3c0