### PR TITLE
Fix Documentor references

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ CoFound.ai implements a dynamic agent workflow system using LangGraph:
 4. **Development**: Developer agent generates code
 5. **Testing**: Tester agent creates and runs tests
 6. **Review**: Reviewer agent analyzes code quality
-7. **Documentation**: Documentor agent creates documentation
+7. **Documentation**: Documenter agent creates documentation
 
 Agents can transfer control to other agents based on task requirements using a handoff mechanism.
 

--- a/demos/projects/proj_1747080029/workflow_thread_proj_1747080029_019c7c78.json
+++ b/demos/projects/proj_1747080029/workflow_thread_proj_1747080029_019c7c78.json
@@ -7,32 +7,32 @@
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     }
   ],

--- a/demos/projects/proj_1747080042/workflow_thread_proj_1747080042_34832f9c.json
+++ b/demos/projects/proj_1747080042/workflow_thread_proj_1747080042_34832f9c.json
@@ -7,32 +7,32 @@
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     }
   ],

--- a/demos/projects/proj_1747080983/workflow_thread_proj_1747080983_e9fd57e1.json
+++ b/demos/projects/proj_1747080983/workflow_thread_proj_1747080983_e9fd57e1.json
@@ -7,32 +7,32 @@
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     }
   ],

--- a/demos/projects/proj_1747081147/workflow_thread_proj_1747081147_cdc2af64.json
+++ b/demos/projects/proj_1747081147/workflow_thread_proj_1747081147_cdc2af64.json
@@ -7,32 +7,32 @@
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     }
   ],

--- a/demos/projects/proj_1747081158/workflow_thread_proj_1747081158_83c53468.json
+++ b/demos/projects/proj_1747081158/workflow_thread_proj_1747081158_83c53468.json
@@ -7,32 +7,32 @@
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     }
   ],

--- a/demos/projects/proj_1747081169/workflow_thread_proj_1747081169_b7fc41cb.json
+++ b/demos/projects/proj_1747081169/workflow_thread_proj_1747081169_b7fc41cb.json
@@ -7,32 +7,32 @@
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     }
   ],

--- a/demos/projects/proj_1747780195/workflow_thread_proj_1747780195_a0318431.json
+++ b/demos/projects/proj_1747780195/workflow_thread_proj_1747780195_a0318431.json
@@ -7,32 +7,32 @@
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     },
     {
       "type": "AIMessage",
-      "content": "[Documentor processed message but can't respond in LangGraph format]",
+      "content": "[Documenter processed message but can't respond in LangGraph format]",
       "additional_kwargs": {}
     }
   ],

--- a/docs/HIGHLEVEL-ARCHITECTURE.txt
+++ b/docs/HIGHLEVEL-ARCHITECTURE.txt
@@ -112,7 +112,7 @@ logs/                           # Logs
   ├── agents/                   # Agent-specific logs
   │   ├── architect/            # Architect agent logs
   │   ├── developer/            # Developer agent logs
-  │   ├── documentor/           # Documentor agent logs
+  │   ├── documentor/           # Documenter agent logs
   │   ├── planner/              # Planner agent logs
   │   ├── reviewer/             # Reviewer agent logs
   │   └── tester/               # Tester agent logs
@@ -262,7 +262,7 @@ CoFound.ai implements a layered architecture that separates concerns and allows 
   - **Developer**: Code implementation and refinement
   - **Tester**: Test creation and execution
   - **Reviewer**: Code review and improvement suggestions
-  - **Documentor**: Documentation creation and maintenance
+  - **Documenter**: Documentation creation and maintenance
 - **Base Agent**: Common functionality shared by all agents
 - **LangGraph Integration**: Wrapper that adapts agents to LangGraph workflows
 
@@ -311,7 +311,7 @@ The CoFound.ai development process follows this general workflow:
 5. **Development Phase**: Developer agent implements code based on design
 6. **Testing Phase**: Tester agent creates and runs tests
 7. **Review Phase**: Reviewer agent evaluates code quality and suggests improvements
-8. **Documentation Phase**: Documentor agent creates user and technical documentation
+8. **Documentation Phase**: Documenter agent creates user and technical documentation
 9. **Delivery**: System provides completed software artifacts to user
 
 ## Agentic Graph Orchestration

--- a/docs/HIGHLEVEL-CHANGELOG.txt
+++ b/docs/HIGHLEVEL-CHANGELOG.txt
@@ -127,7 +127,7 @@ This file tracks high-level changes, implementations, and updates to the CoFound
 
 ### Core Features
 - ✅ **Base Agent System**: Abstract base agent with extensible architecture
-- ✅ **Specialized Agents**: Planner, Architect, Developer, Tester, Reviewer, Documentor
+- ✅ **Specialized Agents**: Planner, Architect, Developer, Tester, Reviewer, Documenter
 - ✅ **CLI Interface**: Command-line interface for workflow execution
 - ✅ **Memory Systems**: Short-term and long-term memory with vector storage
 - ✅ **Tool Integration**: File management and version control tools

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -299,7 +299,7 @@
                         <div class="agent-avatar">
                             <i class="fas fa-book"></i>
                         </div>
-                        <h3>Documentor</h3>
+                        <h3>Documenter</h3>
                         <p>Creates comprehensive documentation and user guides</p>
                         <div class="agent-status">
                             <span class="status-badge ready">Ready</span>


### PR DESCRIPTION
## Summary
- update the documentation to call the agent "Documenter"
- update frontend and demo project logs with the new name

## Testing
- `python run_tests.py unit` *(fails: ModuleNotFoundError: No module named 'pydantic.warnings')*
- `python run_tests.py integration` *(fails: ModuleNotFoundError: No module named 'pydantic.warnings')*

------
https://chatgpt.com/codex/tasks/task_e_68587b05810c8329b83a4485736e8f36