### PR TITLE
Align docs on Documenter agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ CoFound.ai implements a dynamic agent workflow system using LangGraph:
 4. **Development**: Developer agent generates code
 5. **Testing**: Tester agent creates and runs tests
 6. **Review**: Reviewer agent analyzes code quality
-7. **Documentation**: Documentor agent creates documentation
+7. **Documentation**: Documenter agent creates documentation
 
 Agents can transfer control to other agents based on task requirements using a handoff mechanism.
 

--- a/cofoundai/agents/documentor.py
+++ b/cofoundai/agents/documentor.py
@@ -1,7 +1,7 @@
 """
-CoFound.ai Documentor Agent
+CoFound.ai Documenter Agent
 
-This module defines the Documentor agent responsible for creating project documentation.
+This module defines the Documenter agent responsible for creating project documentation.
 """
 
 import logging
@@ -13,7 +13,7 @@ from cofoundai.utils.logger import get_agent_logger
 
 class DocumentorAgent(BaseAgent):
     """
-    Documentor agent responsible for creating project documentation.
+    Documenter agent responsible for creating project documentation.
     
     This agent handles:
     - Creating README files
@@ -24,7 +24,7 @@ class DocumentorAgent(BaseAgent):
     
     def __init__(self, config: Dict[str, Any], test_mode: bool = False):
         """
-        Initialize the documentor agent.
+        Initialize the Documenter agent.
         
         Args:
             config: Dictionary containing the agent's configuration settings
@@ -34,7 +34,7 @@ class DocumentorAgent(BaseAgent):
         self.name = config.get("name", "Documentor")
         self.description = config.get("description", "Agent that creates project documentation")
         self.logger = get_agent_logger(self.name)
-        self.logger.info(f"Documentor agent initialized: {self.name}")
+        self.logger.info(f"Documenter agent initialized: {self.name}")
         self.test_mode = test_mode
     
     def process(self, input_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/docs/HIGHLEVEL-ARCHITECTURE.txt
+++ b/docs/HIGHLEVEL-ARCHITECTURE.txt
@@ -39,7 +39,7 @@ cofoundai/                      # Main package
   │   ├── developer.py          # Code development agent
   │   ├── tester.py             # Testing agent
   │   ├── reviewer.py           # Code review agent
-  │   ├── documentor.py         # Documentation agent
+  │   ├── documentor.py         # Documenter agent
   │   └── langgraph_agent.py    # LangGraph compatible agent implementation
   │
   ├── cli/                      # Command line interface
@@ -112,7 +112,7 @@ logs/                           # Logs
   ├── agents/                   # Agent-specific logs
   │   ├── architect/            # Architect agent logs
   │   ├── developer/            # Developer agent logs
-  │   ├── documentor/           # Documentor agent logs
+  │   ├── documentor/           # Documenter agent logs
   │   ├── planner/              # Planner agent logs
   │   ├── reviewer/             # Reviewer agent logs
   │   └── tester/               # Tester agent logs
@@ -136,7 +136,7 @@ This module contains specialized AI agents that handle different aspects of the 
 - **developer.py**: Code development agent that writes, refactors, and debugs code
 - **tester.py**: Code testing and quality control agent that writes and executes tests
 - **reviewer.py**: Code review and improvement agent that identifies issues and suggests optimizations
-- **documentor.py**: Project documentation agent that creates technical documentation and guides
+- **documentor.py**: Documenter agent that creates technical documentation and guides
 - **langgraph_agent.py**: Base implementation for LangGraph-compatible agents with workflow integration
 - **extensible_agent.py**: Base classes for defining extensible agents
 
@@ -262,7 +262,7 @@ CoFound.ai implements a layered architecture that separates concerns and allows 
   - **Developer**: Code implementation and refinement
   - **Tester**: Test creation and execution
   - **Reviewer**: Code review and improvement suggestions
-  - **Documentor**: Documentation creation and maintenance
+  - **Documenter**: Documentation creation and maintenance
 - **Base Agent**: Common functionality shared by all agents
 - **LangGraph Integration**: Wrapper that adapts agents to LangGraph workflows
 
@@ -311,7 +311,7 @@ The CoFound.ai development process follows this general workflow:
 5. **Development Phase**: Developer agent implements code based on design
 6. **Testing Phase**: Tester agent creates and runs tests
 7. **Review Phase**: Reviewer agent evaluates code quality and suggests improvements
-8. **Documentation Phase**: Documentor agent creates user and technical documentation
+8. **Documentation Phase**: Documenter agent creates user and technical documentation
 9. **Delivery**: System provides completed software artifacts to user
 
 ## Agentic Graph Orchestration

--- a/docs/HIGHLEVEL-CHANGELOG.txt
+++ b/docs/HIGHLEVEL-CHANGELOG.txt
@@ -127,7 +127,7 @@ This file tracks high-level changes, implementations, and updates to the CoFound
 
 ### Core Features
 - ✅ **Base Agent System**: Abstract base agent with extensible architecture
-- ✅ **Specialized Agents**: Planner, Architect, Developer, Tester, Reviewer, Documentor
+- ✅ **Specialized Agents**: Planner, Architect, Developer, Tester, Reviewer, Documenter
 - ✅ **CLI Interface**: Command-line interface for workflow execution
 - ✅ **Memory Systems**: Short-term and long-term memory with vector storage
 - ✅ **Tool Integration**: File management and version control tools

--- a/scripts/visualize_workflow.py
+++ b/scripts/visualize_workflow.py
@@ -98,7 +98,7 @@ def visualize_workflow(workflow: DynamicWorkflow, output_path: Optional[str] = N
             "Developer": "#77DD77",   # Light green
             "Tester": "#FDFD96",      # Light yellow
             "Reviewer": "#FFB347",    # Light orange
-            "Documentor": "#CF9FFF",  # Light purple
+            "Documentor": "#CF9FFF",  # Light purple for Documenter
             "END": "#D3D3D3"          # Light gray
         }
         
@@ -222,7 +222,7 @@ def visualize_agent_interactions(agent_configs: List[Dict[str, Any]], output_pat
             "Developer": "#77DD77",   # Light green
             "Tester": "#FDFD96",      # Light yellow
             "Reviewer": "#FFB347",    # Light orange
-            "Documentor": "#CF9FFF",  # Light purple
+            "Documentor": "#CF9FFF",  # Light purple for Documenter
         }
         
         # Get node colors


### PR DESCRIPTION
## Summary
- update documentation references to use "Documenter" consistently
- clarify agent role in architecture docs and README
- adjust comments mentioning the documentation agent

## Testing
- `python run_tests.py unit` *(fails: PytestConfigWarning, ImportError)*
- `python run_tests.py integration` *(fails: PytestConfigWarning, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68587b28c1bc8329bf7c7969e6548e0d